### PR TITLE
RDKEMW-22169 : use 4.0.8 tag of entservices-apis

### DIFF
--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -21,7 +21,7 @@ git clone --branch  R4.4.3 https://github.com/rdkcentral/ThunderTools.git
 
 git clone --branch R4.4.1 https://github.com/rdkcentral/Thunder.git
 
-git clone --branch main https://github.com/rdkcentral/entservices-apis.git
+git clone --branch 4.0.8 https://github.com/rdkcentral/entservices-apis.git
 
 cd ..
 git clone --branch develop https://github.com/rdkcentral/entservices-helpers.git


### PR DESCRIPTION
Reason: Updated Thunder and ThunderTools version to 4.4.6.
Test Procedure: Refer ticket.
Risks: Medium.
Priority: P0.
Version: Patch